### PR TITLE
:recycle: Small improvements

### DIFF
--- a/undercover.py
+++ b/undercover.py
@@ -14,23 +14,19 @@ WORDS = RULES["WORDS"]
 
 
 # Test rules
-sum_players = 0
-for player in PLAYERS:
-    sum_players += 1
-
-sum_roles = 0
-for role in ROLES:
-    sum_roles += ROLES[role]
+sum_players = len(PLAYERS.keys())
+sum_roles = sum(ROLES.values())
 
 if sum_players != sum_roles:
     raise Exception("[ERROR] Sum of players and sum of roles are different")
 
 
 # Affect roles to players
-remaining_roles = []
-for role in ROLES:
-    for index in range(1, ROLES[role] + 1):
-        remaining_roles.append(role)
+remaining_roles = [
+    role_name
+    for role_name, role_val in ROLES.items()
+    for _ in range(1, role_val + 1)
+]
 
 for player in PLAYERS:
     choose_role = choice(remaining_roles)
@@ -56,4 +52,3 @@ for player in PLAYERS:
 
 
 print(choice(WORDS))
- 


### PR DESCRIPTION
Hello, I've bring some improvements to your code :D

## Explanation

```py
sum_players = 0
for player in PLAYERS:
    sum_players += 1
```

Dictionary have helper methods to cycle through their keys, values or a tuple that contains both of them:

```py
>>> foo.keys()
dict_keys(['foo', 'bar'])
>>> foo.values()
dict_values([42, 88])
>>> foo.items()
dict_items([('foo', 42), ('bar', 88)])
```

They can be iterated in for loops, but also passed to other functions such as `len` or `sum`.

For instance:
```py
>>> sum(foo.values())
130 # 42 + 88
```

which allow to write those two lines:
```py
# Test rules
sum_players = len(PLAYERS.keys())
sum_roles = sum(ROLES.values())
```

## List comprehension

The next one is a bit harder as it involve 2 nested for loops.

When you have something like 

```py
list_x = []
for item in foo:
    list_x.append(item)
```
it can be rewritten as 
```py
list_x = [item for item in foo]
```

This is also the case for nested loops!

```py
list_x = []
for item in foo:
    for sub_item in item
        list_x.append(sub_item)
```

becomes:

```py
list_x = [sub_item for sub_item in item for item in foo]
```
*Note that the 2 for loops are inverted*


Combining this and the `dict.items()` helper, it yield the following code:

> before
```py
remaining_roles = []
for role in ROLES:
    for index in range(1, ROLES[role] + 1):
        remaining_roles.append(role)
```

> dict.items
```py
remaining_roles = []
for role_name, role_val in ROLES.items():
    for index in range(1, role_val + 1):
        remaining_roles.append(role_name)
```

> list comprehension
```py
remaining_roles = [
    role_name
    for role_name, role_val in ROLES.items()
    for _ in range(1, role_val + 1)
]
```